### PR TITLE
ZEP1: define which extensions are part of ZEP1

### DIFF
--- a/draft/ZEP0001.md
+++ b/draft/ZEP0001.md
@@ -228,23 +228,19 @@ following specifications have also been published on the zarr-specs
 website:
 
 * [Codecs](https://zarr-specs.readthedocs.io/en/latest/codecs.html)
+  (part of this ZEP as well)
 
 * Stores - [File system
   store](https://zarr-specs.readthedocs.io/en/latest/stores/filesystem/v1.0.html)
-
-* Array extensions -
-  [Filters](https://zarr-specs.readthedocs.io/en/latest/extensions/array-extensions/filters/v1.0.html)
+  (not part of this ZEP)
 
 * Data types - [Datetime data
   types](https://zarr-specs.readthedocs.io/en/latest/extensions/data-types/datetime/v1.0.html)
+  (not part of this ZEP)
 
 * Storage transformers - [Sharding storage
   transformer](https://zarr-specs.readthedocs.io/en/latest/extensions/storage-transformers/sharding/v1.0.html)
-
-Note that some of these specifications are not complete at this
-time. We leave it open at this time whether the scope of this ZEP
-should be expanded to fully cover all of these specifications, or
-whether further ZEPs should be created to cover these other specs.
+  (part of [ZEP2](https://zarr.dev/zeps/draft/ZEP0002.html))
 
 
 ### Extensibility
@@ -464,6 +460,8 @@ the hierarchy.
 
 3. Discussion around Zarr V3 Protocol:
     * Issues in `zarr-specs`:
+      * ZEP1 project board:
+        * https://github.com/orgs/zarr-developers/projects/2
       * Zarr V3 Mission:
         * https://github.com/zarr-developers/zarr-specs/issues/140
       * Zarr V3 Implementation(Zarrita):


### PR DESCRIPTION
This PR
* defines which extensions/dtypes/stores are part of ZEP1
* adds a link to the ZEP 1 project board to the discussion section.

Should be merged together with https://github.com/zarr-developers/zarr-specs/pull/187