### PR TITLE
Adapts ZEP2 to codec

### DIFF
--- a/draft/ZEP0002.md
+++ b/draft/ZEP0002.md
@@ -180,12 +180,7 @@ Sharding can be configured per array in the array metadata as follows:
     {
       "name": "sharding_indexed"
       "configuration": {
-        "chunk_grid": {
-          "name": "regular",
-          "configuration": {
-            "chunk_shape": [32, 32]
-          }
-        }
+        "chunk_shape": [32, 32],
         "codecs": [
           {
             "name": "gzip",
@@ -200,16 +195,15 @@ Sharding can be configured per array in the array metadata as follows:
 }
 ```
 
-#### `chunk_grid`
+#### `chunk_shape`
 
-Specifies the chunk grid of the inner chunks. The value must be an object,
-as specified in the array metadata.
-Currently, only the `"regular"` chunk grid is supported for inner chunks.
-Each integer of the inner `chunk_shape` must by divisible by the shape of
-the shard (i.e, `chunk_shape` of the array for regular chunk grids).
+An array of integers providing the shape of inner chunks in a shard for each dimension of the Zarr array.
+The length of the array must match the length of the array metadata `shape` entry.
+The each integer must by divisible by the `chunk_shape` of the array as defined in the `chunk_grid` array metadata.  
 For example, an inner chunk shape of `[32, 2]` with an outer chunk shape
 `[64, 64]` indicates that 64 chunks are combined in one shard, 2 along the
 first dimension, and for each of those 32 along the second dimension.
+Currently, only the `"regular"` chunk grid is supported.
 
 #### `codecs`
 
@@ -252,7 +246,7 @@ chunks may be expected. Some writing strategies might be
   order). When replacing existing chunks larger or equal-sized chunks may be
   replaced in-place, leaving unused space up to an upper limit that might
   possibly be specified. Please note that, for regular-sized uncompressed data,
-  all chunks have the same size and can therefore be replaced in-place. > \*
+  all chunks have the same size and can therefore be replaced in-place.
 - **Append-only**: Any chunk to write is appended to the existing shard,
   followed by an updated index. If previous chunks are updated, their storage
   space becomes unused, as well as the previous index. This might be useful for

--- a/draft/ZEP0002.md
+++ b/draft/ZEP0002.md
@@ -1,18 +1,19 @@
 ---
 layout: default
 title: ZEP0002
-description: This ZEP proposes to add a sharding storage transformer to the
+description: This ZEP proposes to add a sharding codec to the
   Zarr specification version 3. This permits combining multiple chunks into
   storage keys, enabling the usage of larger arrays with Zarr.
 parent: draft ZEPs
 nav_order: 2
 ---
 
-# ZEP 2 - Sharding storage transformer
+# ZEP 2 - Sharding codec
 
 Authors:
-* Jonathan Striebel ([@jstriebel](https://github.com/jstriebel)), scalable minds
-* Norman Rzepka ([@normanrz](https://github.com/normanrz)), scalable minds
+
+- Jonathan Striebel ([@jstriebel](https://github.com/jstriebel)), scalable minds
+- Norman Rzepka ([@normanrz](https://github.com/normanrz)), scalable minds
 
 Status: Draft
 
@@ -24,13 +25,11 @@ This ZEP is accompanied by the sharding extension specification
 [[SHARDINGSPEC](#ref-SHARDINGSPEC)]. A public review of the specification is
 done in [PR #@152 of the zarr-specs repo](https://github.com/zarr-developers/zarr-specs/pull/152).
 
-
 ## Abstract
 
-This ZEP proposes to add a sharding storage transformer to the Zarr
+This ZEP proposes to add a sharding codec to the Zarr
 specification version 3. This permits combining multiple chunks into storage
 keys, enabling the usage of larger arrays with Zarr.
-
 
 ## Motivation and Scope
 
@@ -56,7 +55,6 @@ which is called a shard**:
 
 ![sharding schema](../assets/images/sharding.png)
 
-
 The following example illustrates the need for sharding:
 
 The dataset has a shape of `(25000, 18000, 6000)` and a dtype of `uint8`. This
@@ -70,8 +68,7 @@ That would reduce the number of files to ~300 while maintaining a practical
 write granularity.
 
 To allow interoperability between different stores and Zarr implementations, we
-propose to standardize sharding as a storage transformer specification.
-
+propose to standardize sharding as a codec specification.
 
 ## Usage and Impact
 
@@ -96,7 +93,6 @@ allow Zarr to become the standard format also for tera- and peta-scale array
 data and future-proofing it as a standard for the requirements of growing data
 sizes in the scientific community.
 
-
 ## Backward Compatibility
 
 This ZEP introduces a Zarr extension for Zarr version 3. The sharding extension
@@ -104,11 +100,10 @@ is optional for data producers, and only necessary when reading arrays that are
 written using the sharding extension. It corresponds to a minor version change
 in semantic versioning, adding functionality in a backward compatible manner.
 
-As storage transformers are specified in the array metadata, Zarr clients
-without implementation for the sharding extension should infer that they are
-lacking support for the specific array, as all storage transformers are
-required, non-optional extensions.
-
+As codecs are specified in the array metadata, Zarr clients without
+implementation for the sharding extension should infer that they are
+lacking support for the specific array, as all codecs are required,
+non-optional extensions.
 
 ## Detailed description
 
@@ -117,6 +112,7 @@ required, non-optional extensions.
 To add sharding to Zarr, data that was stored previously as separate objects
 must be combined. Different strategies can be considered when sharding array
 data, such as:
+
 1. sharding across single dimensions,
 2. sharding by regular n-dimensional blocks of data, and
 3. sharding random combinations of chunks via hashing.
@@ -138,12 +134,24 @@ chunks as sharding units, as it combines multiple chunks that are close to each
 other. This has the benefit of co-locating data that is usually accessed
 together or in short succession.
 
-
-### Shardings as a storage transformer extension
+### Sharding as a codec extension
 
 Sharding can be an optional addition to the current Zarr features, as it is
 primarily important for very large arrays. Therefore it should be added as an
 extension, which can enhance different Zarr implementations.
+
+Implementing sharding as a codec logically subdivides a chunk into smaller
+chunks ("inner chunks"). This fits well with the codec abstractions that
+encode and decode chunks through various algorithms. With the introduction
+of nested codecs in the sharding configuration inner chunks may be encoded
+further.
+
+Some implementation may want to optimize reading and writing of single inner
+chunk through partial reads and writes as described below. This can be
+implemented by adding information about the chunk selection to the codec's
+API. The experimental [zarrita implementation](https://github.com/scalableminds/zarrita) demonstrates this.
+
+#### Potential alternatives
 
 Sharding by combining different chunks can only be implemented in logical units
 operating after chunking and indexing are done. Therefore it could be
@@ -151,81 +159,112 @@ implemented directly in the storage layer, but this could result in different
 sharding implementations between different stores and Zarr implementations,
 compromising the core Zarr benefit of interoperability.
 
-Therefore, sharding should rather be implemented as a storage transformer, which
-permits consistently addressing array data across different stores and ensures
-compatibility across implementations, by specifying an authoritative
-specification.
-
+Sharding could also be implemented as a storage transformer, which is a new
+concept introduced in Zarr v3. The mental model of sharding would then be
+to group co-located chunks into a larger storage unit. This is inverted from
+the codec model of subdividing chunks into sub-chunks. The codec model has
+some benefits in terms of composability. Other codecs may want to encode
+entire shards, e.g. to add metadata in the binary format. Sharding as a
+storage transformer would make these compositions more difficult.
 
 ### Configuration
 
-Sharding can be configured per array in the array metadata by specifying the
-following array metadata keys:
-* `name` must always be `"sharding` for this storage transformer.
-* `configuration` contains only the following configuration key:
-  * `chunks_per_shard` is an array of integers providing the number of chunks
-    that are combined in a shard for each dimension of the Zarr array, where
-    each chunk may only start at a position that is divisible by
-    `chunks_per_shard` per dimension, e.g. starting at the zero-origin. The
-    length of the array must match the length of the array metadata `shape`
-    entry. For example, a value `[32, 2]` indicates that 64 chunks are combined
-    in one shard, 32 along the first dimension, and for each of those 2 along
-    the second dimension. Some valid starting positions for a shard in the
-    chunk-grid are therefore `[0, 0]`, `[32, 2]`, `[32, 4]`, `[64, 2]` or
-    `[96, 18]`.
+The following part is cited from the accompanying sharding extension
+specification [[SHARDINGSPEC](#ref-SHARDINGSPEC)]:
 
+Sharding can be configured per array in the array metadata as follows:
+
+```json
+{
+  codecs: [
+    {
+      "name": "sharding_indexed"
+      "configuration": {
+        "chunk_grid": {
+          "name": "regular",
+          "configuration": {
+            "chunk_shape": [32, 32]
+          }
+        }
+        "codecs": [
+          {
+            "name": "gzip",
+            "configuration": {
+              "level": 1
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+#### `chunk_grid`
+
+Specifies the chunk grid of the inner chunks. The value must be an object,
+as specified in the array metadata.
+Currently, only the `"regular"` chunk grid is supported for inner chunks.
+Each integer of the inner `chunk_shape` must by divisible by the shape of
+the shard (i.e, `chunk_shape` of the array for regular chunk grids).
+For example, an inner chunk shape of `[32, 2]` with an outer chunk shape
+`[64, 64]` indicates that 64 chunks are combined in one shard, 2 along the
+first dimension, and for each of those 32 along the second dimension.
+
+#### `codecs`
+
+Specifies a list of codecs to be used for encoding and decoding inner chunks.
+The value must be an array of objects, as specified in the array metadata.
+An absent `codecs` member is equivalent to specifying an empty list of codecs.
 
 ### Binary shard format
 
 The following part is cited from the accompanying sharding extension
 specification [[SHARDINGSPEC](#ref-SHARDINGSPEC)]:
 
-> The only binary format is the ``indexed`` format, as specified by the ``type``
-> configuration key. Other binary formats might be added in future versions.
+In the `sharding_indexed` binary format, chunks are written successively in a
+shard, where unused space between them is allowed, followed by an index
+referencing them. The index is placed at the end of the file and has a size of
+16 bytes multiplied by the number of chunks in a shard, for example
+`16 bytes * 4 = 1024 bytes` for shard shape of `[64, 64]` and inner chunk
+shape of `[32, 32]`. The index holds an `offset, nbytes` pair of little-endian
+uint64 per chunk, the chunks-order in the index is row-major (C) order. Given
+the example of 2x2 inner chunks in a shard, the index would look like:
 
-> In the indexed binary format chunks, are written successively in a shard,
-> where unused space between them is allowed, followed by an index referencing
-> them. The index is placed at the end of the file and has a size of 16 bytes
-> multiplied by the number of chunks in a shard, for example
-> ``16 bytes * 64 = 1014 bytes`` for ``chunks_per_shard=[32, 2]``. The index
-> holds an `offset, nbytes` pair of little-endian uint64 per chunk, the
-> chunks-order in the index is row-major (C) order, for example for
-> ``chunks_per_shard=[2, 2]`` an index would look like:
+```
+    | chunk (0, 0)    | chunk (0, 1)    | chunk (1, 0)    | chunk (1, 1)    |
+    | offset | nbytes | offset | nbytes | offset | nbytes | offset | nbytes |
+    | uint64 | uint64 | uint64 | uint64 | uint64 | uint64 | uint64 | uint64 |
+```
 
-> ```
-> | chunk (0, 0)    | chunk (0, 1)    | chunk (1, 0)    | chunk (1, 1)    |
-> | offset | nbytes | offset | nbytes | offset | nbytes | offset | nbytes |
-> | uint64 | uint64 | uint64 | uint64 | uint64 | uint64 | uint64 | uint64 |
-> ```
+Empty chunks are denoted by setting both offset and nbytes to `2^64 - 1`.
+Empty chunks are interpreted as being filled with the fill value. The index
+always has the full shape of all possible chunks per shard, even if they extend
+beyond the array shape.
 
-> Empty chunks are denoted by setting both offset and nbytes to ``2^64 - 1``.
-> The index always has the full shape of all possible chunks per shard, even if
-> they are outside of the array size.
+The actual order of the chunk content is not fixed and may be chosen by the
+implementation. All possible write orders are valid according to this
+specification and therefore can be read by any other implementation. When
+writing partial chunks into an existing shard, no specific order of the existing
+chunks may be expected. Some writing strategies might be
 
-> The actual order of the chunk content is not fixed and may be chosen by the
-> implementation as all possible write orders are valid according to this
-> specification and therefore can be read by any other implementation. When
-> writing partial chunks into an existing shard no specific order of the
-> existing chunks may be expected. Some writing strategies might be
+- **Fixed order**: Specify a fixed order (e.g. row-, column-major, or Morton
+  order). When replacing existing chunks larger or equal-sized chunks may be
+  replaced in-place, leaving unused space up to an upper limit that might
+  possibly be specified. Please note that, for regular-sized uncompressed data,
+  all chunks have the same size and can therefore be replaced in-place. > \*
+- **Append-only**: Any chunk to write is appended to the existing shard,
+  followed by an updated index. If previous chunks are updated, their storage
+  space becomes unused, as well as the previous index. This might be useful for
+  storage that only allows append-only updates.
+- **Other formats**: Other formats that accept additional bytes at the end of
+  the file (such as HDF) could be used for storing shards, by writing the chunks
+  in the order the format prescribes and appending a binary index derived from
+  the byte offsets and lengths at the end of the file.
 
-> * **Fixed order**: Specify a fixed order (e.g. row-, column-major or Morton order).
->   When replacing existing chunks larger or equal-sized chunks may be replaced
->   in-place, leaving unused space up to an upper limit that might possibly be
->   specified. Please note that for regular-sized uncompressed data all chunks
->   have the same size and can therefore be replaced in-place. > *
-> * **Append-only**: Any chunk to write is appended to the existing shard,
->   followed by an updated index. If previous chunks are updated, their
->   storage space becomes unused, as well as the previous index.
->   This might be useful for storage that only allows append-only updates.
-> * **Other formats**: Other formats that accept additional bytes at the end of
->   the file (such as HDF) could be used for storing shards, by writing the chunks
->   in the order the format prescribes and appending a binary index derived from
->   the byte offsets and lengths at the end of the file.
-
-> Any configuration parameters for the write strategy must not be part of the
-> metadata document, they need to be configured at runtime, as this is
-> implementation specific.
-
+Any configuration parameters for the write strategy must not be part of the
+metadata document; instead they need to be configured at runtime, as this is
+implementation specific.
 
 ### Use-cases and access strategies
 
@@ -233,12 +272,13 @@ specification [[SHARDINGSPEC](#ref-SHARDINGSPEC)]:
 
 Reading single chunks can be done in two ways, depending on the capabilities of
 the underlying storage:
-1. * Downloading the complete corresponding shard,
-   * reading the index and
-   * afterwards reading the relevant chunk.
-2. * Downloading only the index of the corresponding shard,
-   * identifying the relevant byte-range for the requested chunk,
-   * only downloading this byte-range from the same shard.
+
+1. - Downloading the complete corresponding shard,
+   - reading the index and
+   - afterwards reading the relevant chunk.
+2. - Downloading only the index of the corresponding shard,
+   - identifying the relevant byte-range for the requested chunk,
+   - only downloading this byte-range from the same shard.
 
 The first method might especially be useful when caching not only the requested
 chunks but the whole shard, which will save bandwidth if subsequent
@@ -249,6 +289,7 @@ chunk-requests are close to the previous chunks.
 Many image acquisition techniques produce slice-wise data, such as timeseries or
 z-slicing. This data can be written slice-wise using one of the following
 techniques:
+
 1. Using a chunk-size and shard-size of 1 for the sliced dimension effectively
    disables chunking and sharding for this dimension.
 2. Slice-wise data with a chunk-size of 1 for the sliced dimension can be
@@ -263,67 +304,69 @@ techniques:
    in the order they arrive, overwriting the old index and appending the updated
    index including the new chunks.
 
-
 #### Updating chunks
 
 Updating chunks can be done with different strategies, depending on the
 byte-length of the chunks and therefore depending on the compression:
-* Uncompressed chunks can be rewritten in-place, since their size is constant
+
+- Uncompressed chunks can be rewritten in-place, since their size is constant
   and the index does not need to be updated.
-* When updating compressed chunks one can also update the chunk in-place if
+- When updating compressed chunks one can also update the chunk in-place if
   there is enough unused space between the chunk and the following chunk (or
   index). However, the index must still be updated if the byte-length of the
   chunk changed.
-* When the compressed chunk is larger than before and no unused space is
+- When the compressed chunk is larger than before and no unused space is
   available, it might either
-  * be appended to the shard, leaving the previous space unused, or
-  * rewriting the shard, moving also other chunks.
-
+  - be appended to the shard, leaving the previous space unused, or
+  - rewriting the shard, moving also other chunks.
 
 ## Related Work
 
-* [Neuroglancer precomputed format](https://github.com/google/neuroglancer/blob/master/src/neuroglancer/datasource/precomputed/sharded.md)
+- [Neuroglancer precomputed format](https://github.com/google/neuroglancer/blob/master/src/neuroglancer/datasource/precomputed/sharded.md)
   supports sharding
-* [webKnossos-wrap](https://github.com/scalableminds/webknossos-wrap#high-level-description),
+- [webKnossos-wrap](https://github.com/scalableminds/webknossos-wrap#high-level-description),
   blocks correspond to Zarr chunks, files to shards
-* [caterva](https://caterva.readthedocs.io/en/latest/getting_started/overview.html),
+- [caterva](https://caterva.readthedocs.io/en/latest/getting_started/overview.html),
   blocks correspond to Zarr chunks, caterva chunks to Zarr shards
-* [Apache Arrow](https://arrow.apache.org/docs/python/dataset.html#reading-partitioned-data)
+- [Apache Arrow](https://arrow.apache.org/docs/python/dataset.html#reading-partitioned-data)
   supports data partitioning
-* The following Zarr v2 sharded store implementation permits having virtual stores which are
+- The following Zarr v2 sharded store implementation permits having virtual stores which are
   serialized into an underlying store: [https://github.com/thewtex/shardedstore](https://github.com/thewtex/shardedstore)
-
 
 ## Implementation
 
-A Python implementation is drafted in the [zarr-python PR #1111](https://github.com/zarr-developers/zarr-python/pull/1111).
+A Python implementation is drafted in the experimental [zarrita implementation](https://github.com/scalableminds/zarrita).
 
 The following proof of concept implementations explored similar approaches:
-  * [https://github.com/alimanfoo/zarrita/pull/40](https://github.com/alimanfoo/zarrita/pull/40)
-  * [https://github.com/zarr-developers/zarr-python/pull/876](https://github.com/zarr-developers/zarr-python/pull/876)
-  * [https://github.com/zarr-developers/zarr-python/pull/947](https://github.com/zarr-developers/zarr-python/pull/947)
 
+- [https://github.com/zarr-developers/zarr-python/pull/1111](https://github.com/zarr-developers/zarr-python/pull/1111).
+- [https://github.com/alimanfoo/zarrita/pull/40](https://github.com/alimanfoo/zarrita/pull/40)
+- [https://github.com/zarr-developers/zarr-python/pull/876](https://github.com/zarr-developers/zarr-python/pull/876)
+- [https://github.com/zarr-developers/zarr-python/pull/947](https://github.com/zarr-developers/zarr-python/pull/947)
 
 ## Discussion
 
 1. Discussions for the specification:
-  * [https://github.com/zarr-developers/zarr-specs/issues/127](https://github.com/zarr-developers/zarr-specs/issues/127)
-  * [https://github.com/zarr-developers/zarr-specs/pull/134](https://github.com/zarr-developers/zarr-specs/pull/134)
-2. Initial issue in `zarr-python`:
-  * [https://github.com/zarr-developers/zarr-python/issues/877](https://github.com/zarr-developers/zarr-python/issues/877)
-3. Other related discussions:
-  * [https://forum.image.sc/t/ome-zarr-chunking-questions/66794](https://forum.image.sc/t/ome-zarr-chunking-questions/66794)
-  * [https://forum.image.sc/t/sharding-support-in-ome-zarr/55409](https://forum.image.sc/t/sharding-support-in-ome-zarr/55409)
-  * [https://forum.image.sc/t/deciding-on-optimal-chunk-size/63023](https://forum.image.sc/t/deciding-on-optimal-chunk-size/63023)
-  * [https://forum.image.sc/t/storing-large-ome-zarr-files-file-numbers-sharding-best-practices/70038](https://forum.image.sc/t/storing-large-ome-zarr-files-file-numbers-sharding-best-practices/70038)
-  * [https://github.com/thewtex/shardedstore/issues/17](https://github.com/thewtex/shardedstore/issues/17)
 
+- [https://github.com/zarr-developers/zarr-specs/issues/127](https://github.com/zarr-developers/zarr-specs/issues/127)
+- [https://github.com/zarr-developers/zarr-specs/pull/134](https://github.com/zarr-developers/zarr-specs/pull/134)
+
+2. Initial issue in `zarr-python`:
+
+- [https://github.com/zarr-developers/zarr-python/issues/877](https://github.com/zarr-developers/zarr-python/issues/877)
+
+3. Other related discussions:
+
+- [https://forum.image.sc/t/ome-zarr-chunking-questions/66794](https://forum.image.sc/t/ome-zarr-chunking-questions/66794)
+- [https://forum.image.sc/t/sharding-support-in-ome-zarr/55409](https://forum.image.sc/t/sharding-support-in-ome-zarr/55409)
+- [https://forum.image.sc/t/deciding-on-optimal-chunk-size/63023](https://forum.image.sc/t/deciding-on-optimal-chunk-size/63023)
+- [https://forum.image.sc/t/storing-large-ome-zarr-files-file-numbers-sharding-best-practices/70038](https://forum.image.sc/t/storing-large-ome-zarr-files-file-numbers-sharding-best-practices/70038)
+- [https://github.com/thewtex/shardedstore/issues/17](https://github.com/thewtex/shardedstore/issues/17)
 
 ## References and Footnotes
 
-* <a name="ref-SHARDINGSPEC"></a> [SHARDINGSPEC] -
-  [https://zarr-specs.readthedocs.io/en/latest/extensions/storage-transformers/sharding/v1.0.html](https://zarr-specs.readthedocs.io/en/latest/extensions/storage-transformers/sharding/v1.0.html)
-
+- <a name="ref-SHARDINGSPEC"></a> [SHARDINGSPEC] -
+  [https://zarr-specs.readthedocs.io/en/latest/extensions/codecs/sharding-indexed/v1.0.html](https://zarr-specs.readthedocs.io/en/latest/extensions/codecs/sharding-indexed/v1.0.html)
 
 ## License
 


### PR DESCRIPTION
Makes changes to the current ZEP2 draft to switch sharding from the storage transformer model to a codec.