### PR TITLE
docs: mark ZEP0003 as Superseded

### DIFF
--- a/superseded/ZEP0003.md
+++ b/superseded/ZEP0003.md
@@ -2,8 +2,10 @@
 layout: default
 title: ZEP0003
 description: Variable chunk sizes
-parent: draft ZEPs
-nav_order: 3
+parent: superseded ZEPs
+nav_order: 1
+
+redirect_from: /draft/ZEP0003
 ---
 
 # ZEP 3 — Variable chunking
@@ -12,13 +14,22 @@ Authors:
 * Martin Durant ([@martindurant](https://github.com/martindurant)), Anaconda, Inc.
 * Isaac Virshup ([@ivirshup](https://github.com/martindurant)), Helmholtz Munich
 
-Status: Draft
+Status: Superseded
 
 Type: Specification
 
 Created: 2022-10-17
 
+Replaced-By: [zarr-extensions `rectilinear` chunk grid](https://github.com/zarr-developers/zarr-extensions/tree/main/chunk-grids/rectilinear)
+
 Discussion: https://github.com/orgs/zarr-developers/discussions/52
+
+> **Note:** This ZEP has been **superseded**. Variable (rectangular) chunking is
+> now specified for Zarr v3 as the
+> [`rectilinear` chunk grid](https://github.com/zarr-developers/zarr-extensions/tree/main/chunk-grids/rectilinear)
+> in the [zarr-extensions](https://github.com/zarr-developers/zarr-extensions)
+> repository, which is the mechanism that replaced per-feature specification ZEPs.
+> The original proposal is retained below for historical reference.
 
 ## Abstract
 

--- a/superseded/superseded_zeps.md
+++ b/superseded/superseded_zeps.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: superseded ZEPs
+description: List of Superseded ZEPs
+nav_order: 5
+has_children: true
+permalink: /superseded_zeps/
+---
+
+# Superseded ZEPs
+
+### Shows the list of Superseded ZEPs.


### PR DESCRIPTION
rectilinear chunks are now supported by the zarr-extensions mechanism: https://github.com/zarr-developers/zarr-extensions/tree/main/chunk-grids/rectilinear

This PR moves ZEP0003 as superseded to avoid confusion (e.g., https://github.com/zarr-developers/zarr-python/issues/3910).
